### PR TITLE
Added tooltip to "delete icon", "post privacy icon", "like icon button" and "comment icon button"

### DIFF
--- a/setup.env
+++ b/setup.env
@@ -1,1 +1,0 @@
-VITE_ENDPOINT=http://localhost:5000/api

--- a/src/components/posts/PostCard/DeletePost.jsx
+++ b/src/components/posts/PostCard/DeletePost.jsx
@@ -7,9 +7,10 @@ export default function DeletePost(props) {
   return (
     <div className="relative">
       <button
-        class="p-2 hover:bg-red-100 dark:hover:bg-red-400 dark:text-white text-xl rounded-full text-red-500"
+        class="tooltip last:p-2 hover:bg-red-100 dark:hover:bg-red-400 dark:text-white text-xl rounded-full text-red-500"
         onClick={() => setOpen(true)}
       >
+        <span className="tooltiptext-delete font-medium">Delete Post</span>
         <AiOutlineDelete />
       </button>
 

--- a/src/components/posts/PostCard/PostComment.jsx
+++ b/src/components/posts/PostCard/PostComment.jsx
@@ -5,13 +5,13 @@ export default function PostComment(props) {
   return (
     <Link
       href={`/posts/${props.postId}`}
-      class="px-4 py-2 flex items-center  justify-center space-x-2 hover:bg-gray-100 dark:hover:bg-gray-600 rounded text-gray-600 dark:text-white font-medium "
+      class="tooltip px-4 py-2 flex items-center  justify-center space-x-2 hover:bg-gray-100 dark:hover:bg-gray-600 rounded text-gray-600 dark:text-white font-medium "
     >
       <span className="text-xl ">
         <FaCommentAlt />
       </span>
 
-      <span class="hidden md:block">Comment</span>
+      <span class="hidden md:block">Comment <span className="tooltiptext-comment">Comment Section</span></span>
     </Link>
   );
 }

--- a/src/components/posts/PostCard/PostHeader.jsx
+++ b/src/components/posts/PostCard/PostHeader.jsx
@@ -42,14 +42,14 @@ export default function PostHeader(props) {
               {props.author.firstName}
             </h6>
           </Link>
-          <div class="flex items-center space-x-2 ">
+          <div class="flex items-center space-x-2">
             <span class="text-sm text-gray-500 dark:text-gray-200">
               {getRelativeTime(props.createdAt)}
             </span>
             <span class="flex items-start dark:text-gray-200">&#8228;</span>
-            <span className="dark:text-gray-200 text-lg">
-              {showPostAudience(props.audience)}
-            </span>
+              <span className="dark:text-gray-200 text-lg tooltip">{showPostAudience(props.audience)}
+                <span class='tooltiptext-privacy font-medium'>{(props.audience)}</span>
+              </span>
           </div>
         </div>
       </div>

--- a/src/components/posts/PostCard/PostHeart.jsx
+++ b/src/components/posts/PostCard/PostHeart.jsx
@@ -3,17 +3,17 @@ import { Show } from "solid-js";
 
 export default function PostHeart(props) {
   return (
-    <button
-      class="px-4 py-2 flex items-center  justify-center space-x-2 hover:bg-gray-100 dark:hover:bg-gray-600 rounded text-gray-600 dark:text-white font-medium "
-      onClick={[props.handleAddRemoveLike]}
-      classList={{"text-blue-500 dark:text-blue-400":props.hasLike}}
-    >
-      <span className="text-xl">
-        <Show when={props.hasLike} fallback={<FaHeart />}>
-          <FaSolidHeart />
-        </Show>
-      </span>
-      <span class="hidden md:block">Like</span>
-    </button>
+      <button
+        class="tooltip px-4 py-2 flex items-center  justify-center space-x-2 hover:bg-gray-100 dark:hover:bg-gray-600 rounded text-gray-600 dark:text-white font-medium "
+        onClick={[props.handleAddRemoveLike]}
+        classList={{ "text-blue-500 dark:text-blue-400": props.hasLike }}
+      >
+        <span className="text-xl">
+          <Show when={props.hasLike} fallback={<FaHeart />}>
+            <FaSolidHeart />
+          </Show>
+        </span>
+        <span class="first:hidden md:block">Like <span className="tooltiptext-heart">Like Button</span></span>
+      </button>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -68,3 +68,127 @@
 
 
 }
+
+/* TOOLTIP CSS */
+
+/* 01. for like button */
+.tooltip .tooltiptext-heart {
+  visibility: hidden;
+  width: 25%;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 150%;
+  left: 26%;
+  margin-left: -60px;
+}
+
+.tooltip .tooltiptext-heart::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext-heart {
+  visibility: visible;
+}
+
+/* 02. for comment section */
+.tooltip .tooltiptext-comment {
+  visibility: hidden;
+  width: 35%;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  bottom: 150%;
+  right: 8%;
+  margin-left: -60px;
+}
+
+.tooltip .tooltiptext-comment::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext-comment {
+  visibility: visible;
+}
+
+
+/* for delete icon */
+.tooltip .tooltiptext-delete {
+  visibility: hidden;
+  width: 350%;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 3px 0;
+  position: absolute;
+  z-index: 1;
+  top: -105%;
+  left: 35.9%;
+  margin-left: -60px;
+  font-size: 15px;
+}
+
+.tooltip .tooltiptext-delete::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext-delete {
+  visibility: visible;
+}
+
+/* Privacy Section */
+.tooltip .tooltiptext-privacy {
+  visibility: hidden;
+  width: 5%;
+  background-color: black;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px 0;
+  position: absolute;
+  z-index: 1;
+  text-align: center;
+  margin-top: 5px;
+  font-size: 13px;
+}
+
+.tooltip .tooltiptext-privacy::after {
+  content: "";
+  position: absolute;
+  border-style: solid;
+  border-color: black transparent transparent transparent;
+}
+
+.tooltip:hover .tooltiptext-privacy {
+  visibility: visible;
+}


### PR DESCRIPTION
I have successfully added tooltip _**"delete icon", "post privacy icon", "like icon button" and "comment icon button"**_ to _**Hydrogen.js**_  frontend as a part of Hacktoberfest 2022.

![Screenshot (153)](https://user-images.githubusercontent.com/81456073/193435550-a502f3b4-7d7b-4f35-9019-714e9977b8e5.png)

![Screenshot (154)](https://user-images.githubusercontent.com/81456073/193435553-b230e915-4a7a-4a4b-b389-f3d5f11fa403.png)

![Screenshot (155)](https://user-images.githubusercontent.com/81456073/193435555-4f5b6c82-fea0-4f8a-9aa2-2f6067397ffc.png)

![Screenshot (156)](https://user-images.githubusercontent.com/81456073/193435557-945820a1-6e7f-4763-ae83-d9e57783c143.png)

