### PR TITLE
feature: File size limit for image upload (#23)

### DIFF
--- a/src/screens/groups/Create.jsx
+++ b/src/screens/groups/Create.jsx
@@ -64,6 +64,7 @@ export default function CreateGroup() {
             removeImage={removeCoverImage}
             title="Group Cover Image"
             btnClass=" flex space-x-2 items-center bg-green-100 text-green-700 px-4 py-2 rounded-md font-medium dark:bg-green-400 dark:text-black"
+            sizeLimit="extended"
           >
             <BiImage className="text-2xl" />
             <span>Cover Image</span>

--- a/src/screens/groups/CreateGroupPost.jsx
+++ b/src/screens/groups/CreateGroupPost.jsx
@@ -40,6 +40,7 @@ export default function CreateGroupPost() {
           removeImage={removeImage}
           title="Group Post Image"
           btnClass="flex items-center space-x-2 bg-gray-200 dark:bg-gray-700 py-2 rounded-md justify-center"
+          sizeLimit="extended"
         >
           <BsImages className="text-green-500 text-2xl" />
           <span>Add image</span>
@@ -47,12 +48,12 @@ export default function CreateGroupPost() {
 
         <div>
           <button
-          disabled={loading()}
+            disabled={loading()}
             type="submit"
             className="w-full py-2 px-3 bg-blue-500 text-white rounded-md text-lg"
           >
             <Show when={!loading()} fallback={"Creating Group Post..."}>
-            Create
+              Create
             </Show>
           </button>
         </div>

--- a/src/screens/groups/groupDetails/index.jsx
+++ b/src/screens/groups/groupDetails/index.jsx
@@ -99,6 +99,7 @@ export default function GroupDetails() {
                       addImage={addCoverImage}
                       removeImage={removeCoverImage}
                       onDone={handleUploadProfilePic}
+                      sizeLimit="extended"
                     >
                       <FaSolidCamera />
                       <span className="hidden md:block">Add Cover Photo</span>

--- a/src/screens/posts/Create.jsx
+++ b/src/screens/posts/Create.jsx
@@ -77,6 +77,7 @@ export default function Create() {
             image={form.image}
             addImage={addImage}
             removeImage={removeImage}
+            sizeLimit="extended"
           >
             <BsImages className="text-green-500" />
           </ImageUpload>

--- a/src/screens/profile/index.jsx
+++ b/src/screens/profile/index.jsx
@@ -99,6 +99,7 @@ export default function Profile() {
                       addImage={addCoverImage}
                       removeImage={removeCoverImage}
                       onDone={handleUploadProfilePic}
+                      sizeLimit="extended"
                     >
                       <FaSolidCamera />
                       <span className="hidden md:block">Add Cover Photo</span>


### PR DESCRIPTION
Fixes #23 

Added a file size checker in the [ImageUpload component](https://github.com/harshmangalam/hydrogen-solidjs-client/blob/89ebd5bf5871979ab63daf9476dc1d79aa1de37f/src/components/shared/ImageUpload.jsx#L8) to check the file size of the image that is selected before uploading it to Cloudinary. 
This file size checker logic is dynamic and is based on what type of image is being uploaded. The uploading will only happen if the required file size is met. The file size limit is
- 2Mb for Post, Group Post, and Cover images.
- 1Mb for all other images.

### About the logic
Basically, the component will look for a `sizeLimit` prop. The file size limit will be 2Mb if  `sizeLimit` prop is set to **extended** else the file size limit will be set to 1Mb. Post, Group Post, and Cover images will have `sizeLimit` of **extended**.

### Screenshots
**Size limit for group image**
![image](https://user-images.githubusercontent.com/46086050/193428025-8f24e14e-4e6d-4e8d-9bd2-baf146a5ec17.png)

**Size limit for cover photos**
![image](https://user-images.githubusercontent.com/46086050/193428055-05c61a31-184a-46b3-9a3a-3c7abfb2be2c.png)
