### PR TITLE
fixes #74: handle long group name properly

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.4.0",
+    "@tailwindcss/line-clamp": "^0.4.2",
     "axios": "^0.26.0",
     "dayjs": "^1.10.8",
     "js-cookie": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@tailwindcss/forms': ^0.4.0
+  '@tailwindcss/line-clamp': ^0.4.2
   autoprefixer: ^10.4.2
   axios: ^0.26.0
   dayjs: ^1.10.8
@@ -19,6 +20,7 @@ specifiers:
 
 dependencies:
   '@tailwindcss/forms': 0.4.0_tailwindcss@3.0.18
+  '@tailwindcss/line-clamp': 0.4.2_tailwindcss@3.0.18
   axios: 0.26.0
   dayjs: 1.10.8
   js-cookie: 3.0.1
@@ -377,6 +379,14 @@ packages:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
     dependencies:
       mini-svg-data-uri: 1.4.3
+      tailwindcss: 3.0.18_55elhoedp6fcgz3377upttmgnu
+    dev: false
+
+  /@tailwindcss/line-clamp/0.4.2_tailwindcss@3.0.18:
+    resolution: {integrity: sha512-HFzAQuqYCjyy/SX9sLGB1lroPzmcnWv1FHkIpmypte10hptf4oPUfucryMKovZh2u0uiS9U5Ty3GghWfEJGwVw==}
+    peerDependencies:
+      tailwindcss: '>=2.0.0 || >=3.0.0 || >=3.0.0-alpha.1'
+    dependencies:
       tailwindcss: 3.0.18_55elhoedp6fcgz3377upttmgnu
     dev: false
 

--- a/src/components/groups/GroupCard.jsx
+++ b/src/components/groups/GroupCard.jsx
@@ -12,7 +12,7 @@ export default function GroupCard(props) {
       <div className="py-4 px-4">
         <div className="flex items-center justify-between gap-4">
           <Link href={`/groups/${props.id}`} className="hover:underline">
-            <h6 className="font-medium text-lg">{props.name}</h6>
+            <h6 className="font-medium text-lg line-clamp-1">{props.name}</h6>
           </Link>
           <UserAvatarTag {...props.admin} />
         </div>

--- a/src/components/groups/groupDetails/ProfileInfo.jsx
+++ b/src/components/groups/groupDetails/ProfileInfo.jsx
@@ -9,7 +9,7 @@ export default function ProfileInfo(props) {
     <div className="flex flex-row justify-end">
       <div className="absolute w-full flex flex-col md:w-auto md:left-1/4 -bottom-48 text-center md:-bottom-32 md:text-left md:items-start">
         <div className="flex items-center justify-center space-x-4">
-          <h3 className="text-3xl dark:text-white font-medium text-center">
+          <h3 className="text-3xl dark:text-white font-medium text-center line-clamp-1">
             {props.name}
           </h3>
           <Show when={authState.currentUser?.id === props.admin.id}>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,5 +4,5 @@ module.exports = {
   theme: {
     extend: {},
   },
-  plugins: [require("@tailwindcss/forms")],
+  plugins: [require("@tailwindcss/forms"), require("@tailwindcss/line-clamp")],
 };


### PR DESCRIPTION
✅ group name in group details page and group card is restricted to max 1 line and ellipsized

Signed-off-by: chankruze <chankruze@gmail.com>