### PR TITLE
Unfriend button should only visible to profile owner

### DIFF
--- a/src/components/friends/FriendBtn.jsx
+++ b/src/components/friends/FriendBtn.jsx
@@ -10,6 +10,7 @@ export default function FriendBtn(props) {
         "text-red-800 bg-red-100 hover:bg-red-200": props.color === "danger",
       }}
       onClick={[props.onClick]}
+      {...props}
     >
       <span>{props.text}</span>
     </button>

--- a/src/screens/friends/MyFriends.jsx
+++ b/src/screens/friends/MyFriends.jsx
@@ -31,6 +31,7 @@ export default function MyFriends() {
               {(user) => (
                 <FriendCard {...user}>
                   <FriendBtn
+                    aria-label="Unfriend"
                     text="Unfriend"
                     color="danger"
                     onClick={() => handleRemoveFromFriendsList(user.id)}

--- a/src/screens/profile/friends/AllFriends.jsx
+++ b/src/screens/profile/friends/AllFriends.jsx
@@ -7,11 +7,14 @@ import Error from "../../../components/shared/Error";
 import Empty from "../../../components/shared/Empty";
 import useFriendRequest from "../../../hooks/useFriendRequest";
 import FriendBtn from "../../../components/friends/FriendBtn";
+import { useAuthState } from "../../../context/auth";
 
 export default function AllFriends() {
   const params = useParams();
   const [resource, { refetch }] = createResource(() => params.userId, fetchUserAllFriends);
   const { handleRemoveFromFriendsList, loading } = useFriendRequest(refetch);
+  const { currentUser } = useAuthState();
+
   return (
     <div className="relative py-4">
       <Switch>
@@ -31,14 +34,17 @@ export default function AllFriends() {
                 {(user) => (
                   <li>
                     <FriendCard {...user}>
-                      <FriendBtn
-                        text="Unfriend"
-                        color="danger"
-                        onClick={() => handleRemoveFromFriendsList(user.id)}
-                        loading={loading}
-                      >
-                        <FaSolidUserMinus size={18} />
-                      </FriendBtn>
+                      <Show when={currentUser.id === params.userId}>
+                        <FriendBtn
+                          aria-label="Unfriend"
+                          text="Unfriend"
+                          color="danger"
+                          onClick={() => handleRemoveFromFriendsList(user.id)}
+                          loading={loading}
+                        >
+                          <FaSolidUserMinus size={18} />
+                        </FriendBtn>
+                      </Show>
                     </FriendCard>
                   </li>
                 )}


### PR DESCRIPTION
### This PR is trying to address the following issue: #101 

### PR content:

- Spreading the props to the internal button inside `FriendBtn` component
- Restrict the visibility of the `Unfriend button` to the correct user